### PR TITLE
Fixes feature set unregister.

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -104,7 +104,7 @@ def register():
 def unregister():
     from bpy.utils import unregister_class
 
-    bpy.types.DATA_PT_rigify_buttons.remove(draw_gamerig_rigify_button)
+    bpy.types.DATA_PT_rigify.remove(draw_gamerig_rigify_button)
 
     # Classes.
     for c in classes:


### PR DESCRIPTION
Feature set registration was updated to use `DATA_PT_rigify` rather than `DATA_PT_rigify_buttons` in bb9469e3a41e578974deaa5d58dc49e05efdba94, but unregistration was not. This PR fixes that oversight.

Can now unload and reload the gamerig feature set from the Rigify feature set list without any error (Blender 4.2.1)